### PR TITLE
rss_rc action: use write instead of _write

### DIFF
--- a/MoinMoin/action/rss_rc.py
+++ b/MoinMoin/action/rss_rc.py
@@ -175,7 +175,7 @@ def execute(pagename, request):
 
         # start SAX stream
         handler.startDocument()
-        handler._write(
+        handler.write(
             u'<!--\n'
             u'    Add an "items=nnn" URL parameter to get more than the \n'
             u'    default %(def_max_items)d items. You cannot get more than \n'


### PR DESCRIPTION
_write was a private function of the RssGenerator class while
.write is a public function that still exists.

Fixes: https://bugs.debian.org/787583
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/werkzeug/wsgi.py", line 588, in __call__
    return self.app(environ, start_response)
  File "/usr/lib/python2.7/dist-packages/MoinMoin/wsgiapp.py", line 264, in __call__
    response = run(context)
  File "/usr/lib/python2.7/dist-packages/MoinMoin/wsgiapp.py", line 89, in run
    response = dispatch(request, context, action_name)
  File "/usr/lib/python2.7/dist-packages/MoinMoin/wsgiapp.py", line 137, in dispatch
    response = handle_action(context, pagename, action_name)
  File "/usr/lib/python2.7/dist-packages/MoinMoin/wsgiapp.py", line 203, in handle_action
    handler(context.page.page_name, context)
  File "/usr/lib/python2.7/dist-packages/MoinMoin/action/rss_rc.py", line 178, in execute
    handler._write(
AttributeError: RssGenerator instance has no attribute '_write'