### PR TITLE
bash lexer: don't include final newline in single line comments.

### DIFF
--- a/MoinMoin/support/pygments/lexers/shell.py
+++ b/MoinMoin/support/pygments/lexers/shell.py
@@ -67,7 +67,7 @@ class BashLexer(RegexLexer):
              r'ulimit|umask|unalias|unset|wait)(?=[\s)`])',
              Name.Builtin),
             (r'\A#!.+\n', Comment.Hashbang),
-            (r'#.*\n', Comment.Single),
+            (r'#.*(?=\n)', Comment.Single),
             (r'\\[\w\W]', String.Escape),
             (r'(\b\w+)(\s*)(\+?=)', bygroups(Name.Variable, Text, Operator)),
             (r'[\[\]{}()=]', Operator),

--- a/MoinMoin/support/pygments/lexers/shell.py
+++ b/MoinMoin/support/pygments/lexers/shell.py
@@ -66,7 +66,7 @@ class BashLexer(RegexLexer):
              r'shopt|source|suspend|test|time|times|trap|true|type|typeset|'
              r'ulimit|umask|unalias|unset|wait)(?=[\s)`])',
              Name.Builtin),
-            (r'\A#!.+\n', Comment.Hashbang),
+            (r'\A#!.+(?=\n)', Comment.Hashbang),
             (r'#.*(?=\n)', Comment.Single),
             (r'\\[\w\W]', String.Escape),
             (r'(\b\w+)(\s*)(\+?=)', bygroups(Name.Variable, Text, Operator)),


### PR DESCRIPTION
Since the final newline character was included in Comment.Single, code blocks that ended in a comment like the following

    {{{#!highlight bash
    echo hello # this command writes "hello" to stdout
    }}}

were getting an extra line at the end.

Using a lookhead assertion instead of matching \n literally fixed the issue.

---

before applying this patch:
![without_patch](https://user-images.githubusercontent.com/20175435/138203542-190f5a5f-596b-4e40-bd8b-78a8494861df.png)

after applying this patch:
![with_patch](https://user-images.githubusercontent.com/20175435/138203534-16554d8c-0d0f-416c-aabe-62530c4cd1b7.png)
