### PR TITLE
Fixes issue #97 to have a clue in the logs when there is a syntax problem and raises Internal Server Error

### DIFF
--- a/MoinMoin/Page.py
+++ b/MoinMoin/Page.py
@@ -1440,7 +1440,11 @@ class Page(object):
 
     def format(self, parser):
         """ Format and write page content without caching """
-        parser.format(self.formatter)
+        try:
+            parser.format(self.formatter)
+        except ValueError:
+            logging.error('======================> %s <==========================' % self.page_name)
+            raise
 
     def execute(self, request, parser, code):
         """ Write page content by executing cache code """

--- a/MoinMoin/wikiutil.py
+++ b/MoinMoin/wikiutil.py
@@ -1506,11 +1506,15 @@ def parse_quoted_separated(args, separator=',', name_value=True, seplimit=0):
                                    seplimit=seplimit)
     for item in l:
         if isinstance(item, tuple):
-            key, value = item
-            if key is None:
-                key = u''
-            keywords[key] = value
-            positional = trailing
+            try:
+                key, value = item
+                if key is None:
+                    key = u''
+                keywords[key] = value
+                positional = trailing
+            except ValueError:
+                logging.error('Poblem %s' item)
+                raise
         else:
             positional.append(item)
 


### PR DESCRIPTION
Ease debugging in case of an Internal Server Error due to a case of problematic syntax such as
[[https://www.waze.com/en/live-map/directions/escola-tecnica-pandia-calogeras-r.-62-90-volta-redonda?place=w.207029799.2070297987.1827329|Waze|targethttps://ul.waze.com/ul?preview_venue_id=207029799.2070297987.1827329&navigate=yes&utm_campaign=default&utm_source=waze_website&utm_medium=lm_share_location="_blank"]]
 