### PR TITLE
replace usemod.com with usemod.org / meatballwiki.org

### DIFF
--- a/MoinMoin/action/pollsistersites.py
+++ b/MoinMoin/action/pollsistersites.py
@@ -4,7 +4,7 @@
 
     This action fetches lists of page urls and page names from sister sites,
     so we can implement SisterWiki functionality.
-    See: http://usemod.com/cgi-bin/mb.pl?SisterSitesImplementationGuide
+    See: http://meatballwiki.org/wiki/?SisterSitesImplementationGuide
 
     @copyright: 2007 MoinMoin:ThomasWaldmann
     @license: GNU GPL, see COPYING for details.

--- a/MoinMoin/action/sisterpages.py
+++ b/MoinMoin/action/sisterpages.py
@@ -4,7 +4,7 @@
 
     This action generates a list of page urls and page names, so that other wikis
     can implement SisterWiki functionality easily.
-    See: http://usemod.com/cgi-bin/mb.pl?SisterSitesImplementationGuide
+    See: http://meatballwiki.org/wiki/?SisterSitesImplementationGuide
 
     @copyright: 2007 MoinMoin:ThomasWaldmann
     @license: GNU GPL, see COPYING for details.

--- a/MoinMoin/action/titleindex.py
+++ b/MoinMoin/action/titleindex.py
@@ -3,7 +3,7 @@
     MoinMoin - "titleindex" action
 
     This action generates a plain list of pages, so that other wikis
-    can implement http://www.usemod.com/cgi-bin/mb.pl?MetaWiki more
+    can implement http://meatballwiki.org/wiki/?MetaWiki more
     easily.
 
     @copyright: 2001 Juergen Hermann <jh@web.de>

--- a/docs/CHANGES
+++ b/docs/CHANGES
@@ -5037,7 +5037,7 @@ New features:
     * Added email notification features contributed by Daniel Sa�    * SystemInfo: show "Entries in edit log"
     * Added "RSS" icon to RecentChanges macro and code to generate a
       RecentChanges RSS channel, see
-          http://www.usemod.com/cgi-bin/mb.pl?UnifiedRecentChanges
+          http://meatballwiki.org/wiki/?UnifiedRecentChanges
       for details
     * Added config.sitename and config.interwikiname parameter
     * Better WikiFarm support:

--- a/wiki/data/intermap.txt
+++ b/wiki/data/intermap.txt
@@ -47,7 +47,7 @@ AltLinux http://altlinux.org/
 AltLinuxEn http://en.altlinux.org/
 hg https://www.mercurial-scm.org/wiki/
 
-## Updated 2004-11-19 from http://www.usemod.com/cgi-bin/mb.pl?InterMapTxt
+## Updated 2004-11-19 from http://meatballwiki.org/wiki/?InterMapTxt
 ## Please modify the upper part of this page only
 
 AbbeNormal http://ourpla.net/cgi/pikie?
@@ -82,7 +82,7 @@ JuraWiki https://jurawiki.de/
 LinuxWiki https://linuxwiki.org/
 LiveJournal http://www.livejournal.com/users/$PAGE/
 LyricWiki http://lyricwiki.org/
-MeatBall http://www.usemod.com/cgi-bin/mb.pl?
+MeatBall http://meatballwiki.org/wiki/?
 MetaWiki http://sunir.org/apps/meta.pl?
 MetaWikiPedia http://meta.wikipedia.org/wiki/
 MoinMaster https://master.moinmo.in/
@@ -103,7 +103,7 @@ ThoughtStorms http://www.nooranch.com/synaesmedia/wiki/wiki.cgi?
 TWiki http://twiki.org/cgi-bin/view/
 UPC http://www.upcdatabase.com/item/
 Unreal http://wiki.beyondunreal.com/wiki/
-UseMod http://www.usemod.com/cgi-bin/wiki.pl?
+UseMod http://www.usemod.org/cgi-bin/wiki.pl?
 WebSeitzWiki http://webseitz.fluxent.com/wiki/
 Wiki http://c2.com/cgi/wiki?
 WikiPedia https://en.wikipedia.org/wiki/


### PR DESCRIPTION
the previous page usemod.com is no longer in use by the original owners and is now used for promotion of gambling

the original authors and owners now use usemod.org and meatballwiki.org for the same purpose

this PR changes the URLs in the code to the new destinations

this does *not* change the URLs also in the installations themselves, which all need to be update manually

fixes https://github.com/moinwiki/moin-1.9/issues/100 equivalent to https://github.com/moinwiki/moin/pull/1731