### PR TITLE
Remove parawiki[.]org (Thai gambling) from intermap.txt

### DIFF
--- a/wiki/data/intermap.txt
+++ b/wiki/data/intermap.txt
@@ -89,7 +89,6 @@ MoinMaster https://master.moinmo.in/
 MoinMoin https://moinmo.in/
 OddMuse http://www.oddmuse.org/
 OpenWiki http://openwiki.com/ow.asp?
-Parawiki http://www.parawiki.org/index.php/ 
 PersonalTelco http://www.personaltelco.net/index.cgi/
 PythonInfo https://wiki.python.org/moin/ 
 PythonWiki http://wiki.python.de/


### PR DESCRIPTION
The Website httpX://parawiki[.]org/ promotes a Thai gambling service

It's similar to #100

Moin2: https://github.com/moinwiki/moin/pull/1732