### PR TITLE
info/diff: stop offering crawlers one url per revision

### DIFF
--- a/MoinMoin/action/diff.py
+++ b/MoinMoin/action/diff.py
@@ -164,9 +164,6 @@ def execute(pagename, request):
 """ % {'button': other_diff_button_html}
 
     prev_oldrev = (oldrev > 1) and (oldrev - 1) or 1
-    next_oldrev = (oldrev < currentrev) and (oldrev + 1) or currentrev
-
-    prev_newrev = (newrev > 1) and (newrev - 1) or 1
     next_newrev = (newrev < currentrev) and (newrev + 1) or currentrev
 
     navigation_html = navigation_html % (title,
@@ -176,22 +173,20 @@ def execute(pagename, request):
 
     request.write(f.rawHTML(navigation_html))
 
-    def rev_nav_link(enabled, old_rev, new_rev, caption, css_classes, enabled_title, disabled_title):
-        if enabled:
-            return currentpage.link_to(request, on=1, querystr={
-                    'action': 'diff',
-                    'rev1': old_rev,
-                    'rev2': new_rev,
-                    }, css_class="diff-nav-link %s" % css_classes, title=enabled_title) + request.formatter.text(caption) + currentpage.link_to(request, on=0)
-        else:
-            return '<span class="diff-no-nav-link %(css_classes)s" title="%(disabled_title)s">%(caption)s</span>' % {
-                'css_classes': css_classes,
-                'disabled_title': disabled_title,
-                'caption': caption,
-                }
+    # Note: there used to be a per-pane navigation of <= < > >= links here,
+    # moving rev1 and rev2 independently. As both sides could be moved on
+    # their own, following those links reached every (rev1, rev2) combination,
+    # which is rev_count*(rev_count-1)/2 distinct urls for a single page - and
+    # each of them renders two revisions plus (for fancy diffs) the whole page
+    # below the diff. Crawlers ignore rel=nofollow and walked all of them.
+    # The same diffs are still available without offering that many urls:
+    # the "Previous change" / "Next change" buttons above step through the
+    # revisions, and the info action has a radio button per revision to
+    # compare any two of them. Both are GET forms, so they cost us nothing
+    # unless somebody actually clicks.
 
     rev_info_html = """
-  <div class="diff-info diff-info-header">%%(rev_first_link)s %%(rev_prev_link)s %(rev_header)s %%(rev_next_link)s %%(rev_last_link)s</div>
+  <div class="diff-info diff-info-header">%(rev_header)s</div>
   <div class="diff-info diff-info-rev-size"><span class="diff-info-caption">%(rev_size_caption)s:</span> <span class="diff-info-value">%%(rev_size)d</span></div>
   <div class="diff-info diff-info-rev-author"><span class="diff-info-caption">%(rev_author_caption)s:</span> <span class="diff-info-value">%%(rev_author)s</span></div>
   <div class="diff-info diff-info-rev-comment"><span class="diff-info-caption">%(rev_comment_caption)s:</span> <span class="diff-info-value">%%(rev_comment)s</span></div>
@@ -204,10 +199,6 @@ def execute(pagename, request):
 }
 
     rev_info_old_html = rev_info_html % {
-        'rev_first_link': rev_nav_link(oldrev > 1, 1, newrev, u'\u21e4', 'diff-first-link diff-old-rev', _('Diff with oldest revision in left pane'), _("No older revision available for diff")),
-        'rev_prev_link': rev_nav_link(oldrev > 1, prev_oldrev, newrev, u'\u2190', 'diff-prev-link diff-old-rev', _('Diff with older revision in left pane'), _("No older revision available for diff")),
-        'rev_next_link': rev_nav_link((oldrev < currentrev) and (next_oldrev < newrev), next_oldrev, newrev, u'\u2192', 'diff-next-link diff-old-rev', _('Diff with newer revision in left pane'), _("Can't change to revision newer than in right pane")),
-        'rev_last_link': '',
         'rev': oldrev,
         'rev_size': oldpage.size(),
         'rev_author': oldlog.getEditor(request) or _('N/A'),
@@ -216,10 +207,6 @@ def execute(pagename, request):
     }
 
     rev_info_new_html = rev_info_html % {
-        'rev_first_link': '',
-        'rev_prev_link': rev_nav_link((newrev > 1) and (oldrev < prev_newrev), oldrev, prev_newrev, u'\u2190', 'diff-prev-link diff-new-rev', _('Diff with older revision in right pane'), _("Can't change to revision older than revision in left pane")),
-        'rev_next_link': rev_nav_link(newrev < currentrev, oldrev, next_newrev, u'\u2192', 'diff-next-link diff-new-rev', _('Diff with newer revision in right pane'), _("No newer revision available for diff")),
-        'rev_last_link': rev_nav_link(newrev < currentrev, oldrev, currentrev, u'\u21e5', 'diff-last-link diff-old-rev', _('Diff with newest revision in right pane'), _("No newer revision available for diff")),
         'rev': newrev,
         'rev_size': newpage.size(),
         'rev_author': newlog.getEditor(request) or _('N/A'),

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -184,35 +184,32 @@ def execute(pagename, request):
             max_count_html = []
             cur_count_added = False
 
-
             for count in max_count_possibilities:
                 # max count value can be not in list of predefined values
                 if max_count <= count and not cur_count_added:
-                    max_count_html.append("".join([
-                        f.span(1, css_class="info-count-item info-cur-count"),
-                        f.text(str(max_count)),
-                        f.span(0),
-                    ]))
+                    max_count_html.append('<option value="%d" selected="selected">%d</option>'
+                                          % (max_count, max_count))
                     cur_count_added = True
 
                 # checking for limit_max_count to prevent showing unavailable options
                 if max_count != count and count <= limit_max_count:
-                    max_count_html.append("".join([
-                        f.span(1, css_class="info-count-item"),
-                        page.link_to(request, on=1, querystr={
-                            'action': 'info',
-                            'offset': str(offset),
-                            'max_count': str(count),
-                            }, css_class="info-count-link", rel="nofollow"),
-                        f.text(str(count)),
-                        page.link_to(request, on=0),
-                        f.span(0),
-                    ]))
+                    max_count_html.append('<option value="%d">%d</option>' % (count, count))
 
+            # This used to be one link per possible count, which gave a crawler
+            # an url per (offset, count) combination. It is a select of the form
+            # around the history table now - the same select-and-press-Do that
+            # the theme uses for its actions menu - so it costs nothing until
+            # somebody actually uses it. The offset has to be carried along, as
+            # it was by those links.
             count_select_html += "".join([
                 f.span(1, css_class="info-count-selector"),
                     f.text(" ("),
-                    f.text(_("%s items per page")) % (f.span(1, css_class="info-count-selector info-count-selector-divider") + f.text(" | ") + f.span(0)).join(max_count_html),
+                    f.text(_("%s items per page")) % (
+                        '<input type="hidden" name="offset" value="%d">'
+                        '<select name="max_count" class="info-count-select">%s</select>'
+                        % (offset, "".join(max_count_html))),
+                    f.rawHTML(' <button type="submit" name="action" value="info">%s</button>'
+                              % wikiutil.escape(_("Do"))),
                     f.text(")"),
                 f.span(0),
             ])

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -103,78 +103,41 @@ def execute(pagename, request):
                 offset = 0
             offset = max(min(offset, log_size - 1), 0)
 
+            # The Newer / Older buttons say which way to move, the offset they
+            # move from comes from the form they are in (see paging_nav_html
+            # below). Moving is done here so that everything after this - the
+            # "showing entries from ... to ..." line, the buttons and the rows
+            # of the listing - sees the offset that is actually shown.
+            offsetmove = request.values.get('offsetmove', u'')
+            if offsetmove == u'newer':
+                offset = ((offset - 1) / max_count) * max_count
+            elif offsetmove == u'older':
+                offset = ((offset + max_count) / max_count) * max_count
+            offset = max(min(offset, log_size - 1), 0)
+
             paging_info_html += f.paragraph(1, css_class="searchstats info-paging-info") + _("Showing page edit history entries from '''%(start_offset)d''' to '''%(end_offset)d''' out of '''%(total_count)d''' entries total.", wiki=True) % {
                 'start_offset': log_size - min(log_size, offset + max_count) + 1,
                 'end_offset': log_size - offset,
                 'total_count': log_size,
             } + f.paragraph(0)
 
-            # generating offset navigating links
+            # generating offset navigation
             if max_count < log_size or offset != 0:
-                offset_links = []
-                cur_offset = max_count
-                near_count = 5 # request.cfg.pagination_size
+                # This used to be a row of links: "Newer", "Older", the first
+                # and the last page of the log and the numbered pages around
+                # the current one. That is an url per page of the listing, and
+                # crawlers walked all of them. Two buttons reach the same
+                # places, one page at a time - they only say which way to go,
+                # the offset they move from is in the form around them.
+                def offset_button(direction, caption, enabled):
+                    return '<button type="submit" name="offsetmove" value="%s"%s>%s</button> ' % (
+                        direction,
+                        not enabled and ' disabled="disabled"' or '',
+                        wikiutil.escape(caption))
 
-                min_offset = max(0, (offset + max_count - 1) / max_count - near_count)
-                max_offset = min((log_size - 1) / max_count, offset / max_count + near_count)
-                offset_added = False
-
-                def add_offset_link(offset, caption=None):
-                    offset_links.append(f.table_cell(1, css_class="info-offset-item") +
-                        page.link_to(request, on=1, querystr={
-                            'action': 'info',
-                            'offset': str(offset),
-                            'max_count': str(max_count),
-                            }, css_class="info-offset-nav-link", rel="nofollow") + f.text(caption or str(log_size - offset)) + page.link_to(request, on=0) +
-                        f.table_cell(0)
-                    )
-
-                # link to previous page - only if not at start
-                if offset > 0:
-                    add_offset_link(((offset - 1) / max_count) * max_count, _("Newer"))
-
-                # link to beggining of event log - if min_offset is not minimal
-                if min_offset > 0:
-                    add_offset_link(0)
-                    # adding gap only if min_offset not explicitly following beginning
-                    if min_offset > 1:
-                        offset_links.append(f.table_cell(1, css_class="info-offset-gap") + f.text(u'\u2026') + f.table_cell(0))
-
-                # generating near pages links
-                for cur_offset in range(min_offset, max_offset + 1):
-                    # note that current offset may be not multiple of max_count,
-                    # so we check whether we should add current offset marker like this
-                    if not offset_added and offset <= cur_offset * max_count:
-                        # current info history view offset
-                        offset_links.append(f.table_cell(1, css_class="info-offset-item info-cur-offset") + f.text(str(log_size - offset)) + f.table_cell(0))
-                        offset_added = True
-
-                    # add link, if not at this offset
-                    if offset != cur_offset * max_count:
-                        add_offset_link(cur_offset * max_count)
-
-                # link to the last page of event log
-                if max_offset < (log_size - 1) / max_count:
-                    if max_offset < (log_size - 1) / max_count - 1:
-                        offset_links.append(f.table_cell(1, css_class="info-offset-gap") + f.text(u'\u2026') + f.table_cell(0))
-                    add_offset_link(((log_size - 1) / max_count) * max_count)
-
-                # special case - if offset is greater than max_offset * max_count
-                if offset > max_offset * max_count:
-                    offset_links.append(f.table_cell(1, css_class="info-offset-item info-cur-offset") + f.text(str(log_size - offset)) + f.table_cell(0))
-
-                # link to next page
-                if offset < (log_size - max_count):
-                    add_offset_link(((offset + max_count) / max_count) * max_count, _("Older"))
-
-                # generating html
-                paging_nav_html += "".join([
-                    f.table(1, css_class="searchpages"),
-                    f.table_row(1),
-                    "".join(offset_links),
-                    f.table_row(0),
-                    f.table(0),
-                ])
+                paging_nav_html += (
+                    offset_button('newer', _("Newer"), offset > 0) +
+                    offset_button('older', _("Older"), offset < (log_size - max_count)))
 
         # generating max_count switcher
         # we do it only in case history_count has additional values
@@ -196,20 +159,18 @@ def execute(pagename, request):
                     max_count_html.append('<option value="%d">%d</option>' % (count, count))
 
             # This used to be one link per possible count, which gave a crawler
-            # an url per (offset, count) combination. It is a select of the form
-            # around the history table now - the same select-and-press-Do that
-            # the theme uses for its actions menu - so it costs nothing until
-            # somebody actually uses it. The offset has to be carried along, as
-            # it was by those links.
+            # an url per (offset, count) combination. It is a select of the
+            # paging form now - the same select-and-press-Do that the theme
+            # uses for its actions menu - so it costs nothing until somebody
+            # actually uses it. That form carries the action and the offset,
+            # so this button needs no name of its own.
             count_select_html += "".join([
                 f.span(1, css_class="info-count-selector"),
                     f.text(" ("),
                     f.text(_("%s items per page")) % (
-                        '<input type="hidden" name="offset" value="%d">'
                         '<select name="max_count" class="info-count-select">%s</select>'
-                        % (offset, "".join(max_count_html))),
-                    f.rawHTML(' <button type="submit" name="action" value="info">%s</button>'
-                              % wikiutil.escape(_("Do"))),
+                        % "".join(max_count_html)),
+                    f.rawHTML(' <button type="submit">%s</button>' % wikiutil.escape(_("Do"))),
                     f.text(")"),
                 f.span(0),
             ])
@@ -330,22 +291,41 @@ def execute(pagename, request):
         div = html.DIV(id="page-history")
         div.append(history_table.render(method="GET"))
 
-        form = html.FORM(method="GET", action="")
-        if paging:
-            form.append(f.div(1, css_class="info-paging-info") + paging_info_html + count_select_html + f.div(0))
-            form.append("".join([
-                f.div(1, css_class="info-paging-nav info-paging-nav-top"),
-                paging_nav_html,
+        # The paging controls are a form of their own, next to (not inside) the
+        # one around the history table: that one can not have a fixed action,
+        # its buttons each bring their own, while these all mean action=info.
+        # So a hidden input can carry it here, which leaves the buttons free to
+        # say what they do - pick a count, or move a page.
+        def paging_form(css_class, content, hidden_max_count=False):
+            return "".join([
+                '<form method="GET" action="">',
+                f.div(1, css_class=css_class),
+                '<input type="hidden" name="action" value="info">',
+                '<input type="hidden" name="offset" value="%d">' % offset,
+                hidden_max_count and '<input type="hidden" name="max_count" value="%d">' % max_count or '',
+                content,
                 f.div(0),
-            ]))
-        form.append(div)
+                '</form>',
+            ])
+
         if paging:
-            form.append("".join([
-                f.div(1, css_class="info-paging-nav info-paging-nav-bottom"),
-                paging_nav_html,
-                f.div(0)
-            ]))
-        request.write(unicode(form))
+            request.write(paging_form("info-paging-info",
+                                      paging_info_html + count_select_html + paging_nav_html))
+
+        # The table brings its own form - that is what render(method="GET")
+        # does - and the radio buttons and the two column header buttons are
+        # inside it. There used to be another form around it here, holding the
+        # hidden action=diff; now that those buttons carry their action
+        # themselves, that outer form would only be a form nested in a form,
+        # which is not allowed and which browsers resolve by dropping the
+        # inner start tag, so that the inner </form> ends the outer one.
+        request.write(unicode(div))
+
+        if paging:
+            # down here the count select is out of reach, so the count the
+            # buttons move within has to be carried along
+            request.write(paging_form("info-paging-nav info-paging-nav-bottom",
+                                      paging_nav_html, hidden_max_count=True))
 
     # main function
     _ = request.getText

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -225,24 +225,30 @@ def execute(pagename, request):
             Column('rev', label='#', align='right'),
             Column('mtime', label=_('Date'), align='right'),
             Column('size', label=_('Size'), align='right'),
-            Column('diff', label='<input type="submit" value="%s">' % (_("Diff"))),
+            # both column headers submit the one form around the table, the
+            # pressed button decides which action the form runs
+            Column('diff', label='<button type="submit" name="action" value="diff">%s</button>' % (_("Diff"))),
             Column('editor', label=_('Editor'), hidden=not request.cfg.show_names),
             Column('comment', label=_('Comment')),
-            Column('action', label=_('Action')),
+            Column('action', label='<button type="submit" name="action" value="info">%s</button>' % (_("Do"))),
             ]
 
         # generate history list
 
-        def render_action(text, query, **kw):
-            kw.update(dict(rel='nofollow'))
-            return page.link_to(request, text, querystr=query, **kw)
+        # The actions of a row used to be links, which gave a crawler one url
+        # per revision and per attachment, each of them rendering a complete
+        # page. They are radio buttons of a single group now: picking one and
+        # pressing the button in the column header runs it, and crawlers do not
+        # submit forms. See the rowaction handling in execute() below.
+        def render_action(text, value):
+            return '<input type="radio" name="rowaction" value="%s">%s' % (
+                wikiutil.escape(value, True), wikiutil.escape(text))
 
-        def render_file_action(text, pagename, filename, request, do):
-            url = AttachFile.getAttachUrl(pagename, filename, request, do=do)
-            if url:
-                f = request.formatter
-                link = f.url(1, url) + f.text(text) + f.url(0)
-                return link
+        def render_file_action(text, filename, do):
+            # do not offer what this file has no handler for (as before: the
+            # link was left out when getAttachUrl() had nothing to point to)
+            if AttachFile.get_action(request, filename, do):
+                return render_action(text, u'AttachFile:%s:%s' % (do, filename))
 
         may_write = request.user.may.write(pagename)
         may_delete = request.user.may.delete(pagename)
@@ -259,7 +265,7 @@ def execute(pagename, request):
             actions = []
             if line.action in ('SAVE', 'SAVENEW', 'SAVE/REVERT', 'SAVE/RENAME', ):
                 size = page.size(rev=rev)
-                actions.append(render_action(_('view'), {'action': 'recall', 'rev': '%d' % rev}))
+                actions.append(render_action(_('view'), u'recall:%d' % rev))
                 if pgactioncount == 0:
                     rchecked = ' checked="checked"'
                     lchecked = ''
@@ -291,12 +297,12 @@ def execute(pagename, request):
                 comment = "%s: %s %s" % (line.action, filename, line.comment)
                 if AttachFile.exists(request, pagename, filename):
                     size = AttachFile.size(request, pagename, filename)
-                    actions.append(render_file_action(_('view'), pagename, filename, request, do='view'))
-                    actions.append(render_file_action(_('get'), pagename, filename, request, do='get'))
+                    actions.append(render_file_action(_('view'), filename, 'view'))
+                    actions.append(render_file_action(_('get'), filename, 'get'))
                     if may_delete:
-                        actions.append(render_file_action(_('del'), pagename, filename, request, do='del'))
+                        actions.append(render_file_action(_('del'), filename, 'del'))
                     if may_write:
-                        actions.append(render_file_action(_('edit'), pagename, filename, request, do='modify'))
+                        actions.append(render_file_action(_('edit'), filename, 'modify'))
                 else:
                     size = 0
 
@@ -325,7 +331,6 @@ def execute(pagename, request):
         history_table.setData(history)
 
         div = html.DIV(id="page-history")
-        div.append(html.INPUT(type="hidden", name="action", value="diff"))
         div.append(history_table.render(method="GET"))
 
         form = html.FORM(method="GET", action="")
@@ -348,6 +353,26 @@ def execute(pagename, request):
     # main function
     _ = request.getText
     page = Page(request, pagename)
+
+    # A row action was selected in the history and the form was submitted (see
+    # render_action() above): send the browser to the action it stands for.
+    # The url is built here from a fixed set of actions, the submitted value
+    # only selects one of them and gives its target, so this can not be used to
+    # send anybody somewhere else. The actions check their own permissions, as
+    # they did when these were links.
+    rowaction = request.values.get('rowaction', u'')
+    if rowaction:
+        what = rowaction.split(u':', 2)
+        url = None
+        if len(what) == 2 and what[0] == u'recall' and what[1].isdigit():
+            url = page.url(request, querystr={'action': 'recall', 'rev': str(int(what[1]))})
+        elif len(what) == 3 and what[0] == u'AttachFile' and what[1] in ('view', 'get', 'del', 'modify'):
+            # getAttachUrl() creates the ticket the destructive ones need
+            url = AttachFile.getAttachUrl(pagename, what[2], request, do=what[1])
+        if url:
+            request.http_redirect(url)
+            return
+
     title = page.split_title()
 
     request.setContentLanguage(request.lang)

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -310,7 +310,7 @@ def execute(pagename, request):
 
         if paging:
             request.write(paging_form("info-paging-info",
-                                      paging_info_html + count_select_html + paging_nav_html))
+                                      paging_info_html + count_select_html))
 
         # The table brings its own form - that is what render(method="GET")
         # does - and the radio buttons and the two column header buttons are

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -268,9 +268,14 @@ def execute(pagename, request):
                     rchecked = ''
                 else:
                     lchecked = rchecked = ''
+                # Note: there used to be a "to previous" diff link per row here.
+                # Those links were the diff urls a crawler picked up from this
+                # page - one per revision, each of them rendering two revisions
+                # and (for fancy diffs) the whole page below the diff. The radio
+                # buttons in this same column do that and more, they compare any
+                # two of the listed revisions, and being a GET form they are not
+                # followed by crawlers.
                 diff = '<input type="radio" name="rev1" value="%d"%s><input type="radio" name="rev2" value="%d"%s>' % (rev, lchecked, rev, rchecked)
-                if rev > 1:
-                    diff += render_action(' ' + _('to previous'), {'action': 'diff', 'rev1': rev-1, 'rev2': rev})
                 comment = line.comment
                 if not comment:
                     if '/REVERT' in line.action:

--- a/MoinMoin/action/info.py
+++ b/MoinMoin/action/info.py
@@ -379,19 +379,29 @@ def execute(pagename, request):
     f = request.formatter
 
     request.theme.send_title(_('Info for "%s"') % (title, ), page=page)
+    # (label, name of the parameter that selects this view - the revision
+    # history is what info shows when neither of the others is asked for)
     menu_items = [
-        (_('Show "%(title)s"') % {'title': _('Revision History')},
-         {'action': 'info'}),
-        (_('Show "%(title)s"') % {'title': _('General Page Infos')},
-         {'action': 'info', 'general': '1'}),
-        (_('Show "%(title)s"') % {'title': _('Page hits and edits')},
-         {'action': 'info', 'hitcounts': '1'}),
+        (_('Show "%(title)s"') % {'title': _('Revision History')}, None),
+        (_('Show "%(title)s"') % {'title': _('General Page Infos')}, 'general'),
+        (_('Show "%(title)s"') % {'title': _('Page hits and edits')}, 'hitcounts'),
     ]
     request.write(f.div(1, id="content")) # start content div
-    request.write(f.paragraph(1))
-    for text, querystr in menu_items:
-        request.write("[%s] " % page.link_to(request, text=text, querystr=querystr, rel='nofollow'))
-    request.write(f.paragraph(0))
+    # These used to be links, giving a crawler three urls on every page of the
+    # wiki - and the first of them leads on to the whole page history. A GET
+    # form shows the same three views to a reader, and crawlers do not submit
+    # forms. The button that shows the history needs no name of its own, it
+    # just leaves general and hitcounts unset.
+    request.write(f.rawHTML('<form method="GET" action="%s"><div>'
+                            '<input type="hidden" name="action" value="info">'
+                            % wikiutil.escape(page.url(request), True)))
+    for text, name in menu_items:
+        if name:
+            button = '<button type="submit" name="%s" value="1">%s</button> ' % (name, wikiutil.escape(text))
+        else:
+            button = '<button type="submit">%s</button> ' % wikiutil.escape(text)
+        request.write(f.rawHTML(button))
+    request.write(f.rawHTML('</div></form>'))
 
     show_hitcounts = int(request.values.get('hitcounts', 0)) != 0
     show_general = int(request.values.get('general', 0)) != 0

--- a/MoinMoin/config/multiconfig.py
+++ b/MoinMoin/config/multiconfig.py
@@ -949,7 +949,7 @@ options_no_group_name = {
 
     ('edit_bar', ['Edit', 'Comments', 'Discussion', 'Info', 'Subscribe', 'Quicklink', 'Attachments', 'ActionsMenu'],
      'list of edit bar entries'),
-    ('history_count', (100, 200, 5, 10, 25, 50), "Number of revisions shown for info/history action (default_count_shown, max_count_shown, [other values shown as page size choices]). At least first two values (default and maximum) should be provided. If additional values are provided, user will be able to change number of items per page in the UI."),
+    ('history_count', (25, 200, 5, 10, 50, 100), "Number of revisions shown for info/history action (default_count_shown, max_count_shown, [other values shown as page size choices]). At least first two values (default and maximum) should be provided. If additional values are provided, user will be able to change number of items per page in the UI."),
     ('history_paging', True, "Enable paging functionality for info action's history display."),
 
     ('show_hosts', True,


### PR DESCRIPTION
## Problem

Crawlers walk the info action and everything it links, endlessly. Every link set on those
pages was feeding them, and all of them already carried `rel=nofollow`, which the crawlers
causing the load ignore:

1. **The diff view's per-pane navigation** (`⇤ ← → ⇥`) moved `rev1` and `rev2` independently,
   so following those links reached **every `(rev1, rev2)` pair** - `N*(N-1)/2` urls for a
   page with N revisions.
2. **The info action's "to previous" link**, one per listed revision, which seeded the above.
3. **The info action's "action" column**: `view` (`action=recall`) per revision, plus
   view/get/del/edit per attachment entry.
4. **The info action's view menu**: three urls on every page of the wiki.
5. **The "N items per page" switcher**: one link per count, each carrying the current offset.
6. **The history paging**: "Newer", "Older", first, last and the numbered pages around the
   current one - an url per page of the listing, per items-per-page setting.

Every url in 1-3 renders at least one full revision; a diff url renders two, plus the whole
page below it when fancy diffs are on (the default).

The "diff" column of the history table never had this problem, because it uses radio buttons
inside a form - and crawlers do not submit forms. These commits apply that same approach to
everything else on the page.

## Measured

Crawling the links moin actually emits, on a page with 60 revisions:

| | reachable diff urls | wall time to serve |
|---|---|---|
| before | **1770** (= all pairs) | 35.1 s |
| after commit 1 | 59 (the info seeds) | 0.8 s |
| after commit 2 | **0** | - |

A page with 200 revisions went from 19900 diff urls to 0.

For a real page with 374 log entries the whole reachable set was 69751 diff urls + 374 recall
urls + 450 info urls = **70575 urls**, at least 12 minutes of cpu to walk once. It is 0 now.

And the default history view got cheaper to serve, measured on a page with 61 log entries:

| default | rows | ms | bytes |
|---|---|---|---|
| 25 (now) | 25 | **14.4** | **21762** |
| 100 (before) | 61 | 21.9 | 37127 |

What a crawler can find per page after these commits:

| source | `action=` urls offered |
|---|---|
| page view | 0 |
| `?action=info`, paged or not | 0 |
| a diff page | 0 |
| RecentChanges | 1 diff per changed page (a dead end - it links no further diffs) |

## The commits

**1. `diff`: remove the per-pane revision navigation links.** The equivalent navigation
survives as the existing "Previous change" / "Next change" GET forms, which always produce a
span-1 pair no matter where you are, so the reachable set stays closed even against a crawler
that submits forms. Arbitrary pairs remain available through the info action's radio buttons.

**2. `info`: remove the "to previous" diff link from the history rows.** The rev1/rev2 radio
buttons in the same column do that and more - any two listed revisions, not just neighbours -
and their preselected pair is the two newest revisions.

**3. `info`: offer the row actions as a radio group instead of as links.** A row can offer
several actions and a form control carries only one `name=value` pair, so the actions became
one radio group (`rowaction`) with a submit button in the column header; `execute()` maps the
selection onto the action and redirects. The url is rebuilt from a fixed set of actions - the
submitted value only selects one of them and names its target - so it cannot redirect
anywhere else, unknown values just re-render the info page, the actions still check their own
permissions, and the attachment url still comes from `getAttachUrl()` so the destructive ones
still get their ticket.

**4. `info`: offer the view menu as a form instead of as links.** Three submit buttons of a
GET form. The one for the revision history needs no name of its own, it just leaves `general`
and `hitcounts` unset.

**5. `info`: offer the items per page switcher as a select instead of as links.** A select
plus a Do button, the same select-and-press pattern the theme uses for its actions menu. The
select goes where the list of counts went in `"%s items per page"`, so the msgid and the word
order stay usable for translations, and the current count is the preselected option even when
it is not one of the configured values.

**6. `info`: offer the history paging as two buttons instead of as links.** "Newer" and
"Older", one page per press, disabled at the respective end. They carry the direction, not a
target offset - the offset they move from is in the form around them - and the move happens
where the offset is parsed, so the "showing entries from ... to ..." line, the buttons and the
listed rows all agree about what is shown.

**7. `info`: show the Newer/Older buttons only below the history table.** They were rendered
twice, above and below the listing, as the row of paging links was before them.

**8. `config`: show 25 history entries per page by default, not 100.** A hundred rows is a
lot to build for a view most visitors only glance at - each row stats a revision for its size
column. Only the first value of `history_count` changes: 100 moves from the default slot into
the list of choices, so 5, 10, 25, 50, 100 and 200 are all still selectable and the maximum
stays 200. Paging further is cheap now that it is two buttons rather than an url per page.

## Form layout

A submit button carries one `name=value`, so a button cannot both name an action and say what
it does. The page therefore has three kinds of form, none of them nested:

* the **view menu** and the **paging controls**: a hidden `action=info`, so their buttons are
  free to say `general=1`, `hitcounts=1` or `offsetmove=older`
* the form around the **history table**: no fixed action, each column header button brings its
  own (`action=diff` for Diff, `action=info` for the row actions)

Commit 6 also drops the outer form that used to wrap the history table: it held the hidden
`action=diff`, which the header buttons replaced, and it was nested around the form that
`DataBrowserWidget.render(method="GET")` produces. A form in a form is not allowed, and
browsers resolve it by dropping the inner start tag, so the inner `</form>` was ending the
outer one. The table's own form is the real one now.

## What users lose

* Changing the compared revisions from within the diff view - go back to info and pick a pair.
* One-click diff of a history row against its predecessor - select two revisions, press Diff.
* One-click row actions - select the action, press the column header button, plus a redirect.
* One-click switch of the view and of the items per page - press a button / pick and press Do.
* Jumping straight to a far away page of the history - the buttons move one page per press.
  The numbered links only offered the pages near the current one plus the first and the last,
  so the middle of a long history already took several clicks.
* Pressing the row action button without having selected a row now re-renders the history at
  the top rather than at the current offset.
* The history starts at 25 entries per page rather than 100. The selector still offers 100 and
  200 for anybody who wants a longer listing.

## Notes

* Detected spiders were never the problem here: `check_forbidden()` already returns 403 for
  `isSpiderAgent` on any url with query args. This is aimed at the crawlers sending browser
  user agents.
* The msgids of the removed link texts stay in the i18n catalogs unused.
* No css cleanup needed - neither the `diff-nav-link` / `diff-no-nav-link` classes nor any of
  the `info-*` classes were styled by any bundled theme.

## Verified

Driven over HTTP (`werkzeug.test.Client`) against a real wiki with a generated 60-revision
page plus an attachment:

* no `href` with `action=` anywhere in the info view, paged or not, nor in a diff view
* every `<form>` closes before the next one opens - no nesting left on the page
* Diff button -> the selected pair's diff; `recall:30` -> 302 -> renders revision 30;
  `AttachFile:get:notes.txt` -> 302 -> serves the file; `AttachFile:del` -> 302 with a ticket
* hand-crafted `rowaction` values (`http://evil.example/`, `//evil.example/`, `Despam:x:y`,
  `recall:abc`, `recall:-1`, `AttachFile:get:../../etc/passwd`, malformed ones) either
  re-render info or redirect locally
* each menu button lands on its view; the switcher offers exactly the configured counts with
  the current one preselected, and `max_count=5/25/200` yield 5/25/61 rows
* Newer/Older move exactly one page from offsets 0/25/50, are disabled at the ends, pressing
  them there is a no-op, and they are rendered once, below the table
* the default listing shows 25 rows with 25 preselected in the selector, and the selector
  still offers exactly 5, 10, 25, 50, 100, 200
* a logged in user sees the same number of entries as an anonymous one (checked with a real
  login): the count comes from the config and the request, never from the user
* diff renders with both revision headers, no leftover format placeholders, size/editor/comment
  rows intact, fancy diff still emits the page below; its three GET forms are unchanged
* the info radio form still reaches any pair (5/50, 1/60, 59/60, 1/2)
* `?action=diff` bare, with `rev1==rev2`, with only `rev2`, with out-of-range revs -> 200
* the non-fancy branch (`show_fancy_diff` off) renders and still offers its `ignorews` link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
